### PR TITLE
temp fix, error report standard needs to change

### DIFF
--- a/example_questions/programming/first_non_repeat_char/1.0/question
+++ b/example_questions/programming/first_non_repeat_char/1.0/question
@@ -86,10 +86,10 @@ else:
 
 try:
 	answer = fnrc("@@pquest.qstring@@")
-	error = ''
+	serror = ''
 except Exception as e:
     answer = ''
-    error = str(e)
+    serror = str(e)
 %}
 
 {%python2:aquest
@@ -134,7 +134,7 @@ else:
 		If your code threw any errors, they are displayed below:
 	</p>
 	<code>
-		@@nquest.error@@
+		@@nquest.serror@@
 	</code>
 </div>
 


### PR DESCRIPTION
this is a just a fix to an example question concerning the following:

microservices are reporting 'error' = ... when an exception occurs. if a question writer uses creates/requests a variable named 'error' then the error reporting will be automatically triggered. this shouldn't happen. 'error' should be replaced by a reserved name like 'qengine_error'. this requires updating all microservices